### PR TITLE
windows 下无限循环 bugfix

### DIFF
--- a/lib/finder.js
+++ b/lib/finder.js
@@ -120,12 +120,30 @@ function findConfigs(filename, start, stopper, loader) {
 
     var root = path.resolve('/');
 
+    // windows 下可能存在盘符不一致， 或者盘符大小写不一致的情况
+    // 比如此处，可能存在下列几种情况：
+    //     1: root === 'C:\', start === 'C:\test.js'
+    //     2: root === 'C:\', start === 'c:\test.js'
+    //     3: root === 'C:\', start === 'D:\test.js'
+    //     4: root === 'C:\', start === 'd:\test.js'
+    // 其中， 2， 3， 4 三种情况会导致后续的 while 循环变成无限循环
+    // 此处将 root 的大小写和 start 保持一致
+    if (/^[a-z]:/i.test(root) && /^[a-z]:/i.test(start)) {
+        if (/^[a-z]:/.test(start)) {
+            root = root.toLowerCase();
+        }
+        else {
+            root = root.toUpperCase();
+        }
+    }
+
     stopper = stopper || function (start, root, configs) {
         return start === root;
     };
 
     var configs = [];
     var filepath;
+    var last;
 
     /* eslint-disable no-constant-condition */
     while (true) {
@@ -143,7 +161,16 @@ function findConfigs(filename, start, stopper, loader) {
             break;
         }
 
+        last = start;
         start = path.resolve(start, '..');
+
+        // windows 下， 如果进行到根目录， 上面的 resolve 执行后没有变化
+        // 即 path.resolve('D:\', '..') === 'D:\'
+        // 此时若 root 为不同盘符， 比如'C:\', 上面的默认 stopper 会永远返回 false
+        // 成为无限循环， 此处判断后 break
+        if (last === start) {
+            break;
+        }
     }
     /* eslint-enable no-constant-condition */
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -24,9 +24,12 @@ exports.extend = function extend(target) {
         for (var key in src) {
             if (hasOwnProperty.call(src, key)) {
 
-                if (toString.call(src[key]) === '[object Object]'
-                    && toString.call(target[key]) === '[object Object]'
-                ) {
+                if (toString.call(src[key]) === '[object Object]') {
+
+                    if (toString.call(target[key]) !== '[object Object]') {
+                        target[key] = {};
+                    }
+
                     extend(target[key], src[key]);
                 }
                 else {


### PR DESCRIPTION
findConfigs 函数在 windows 下，可能会因为盘符不一致或盘符大小写不一致而导致无限循环。